### PR TITLE
Missing OpenTelemetry package version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+composer.phar
+composer.lock
+vendor/
+tests/coverage
+
+# IntelliJ IDEA
+.idea
+*.iml
+
+# VS Code
+.vscode
+
+# OS X
+.DS_Store

--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,8 @@
       "role": "Developer"
     }],
   "require": {
-    "php-http/guzzle7-adapter": "^1.0",
-    "open-telemetry/opentelemetry": "^1.0"
+    "open-telemetry/opentelemetry": "^1.0",
+    "php-http/guzzle7-adapter": "^1.0"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,9 @@
     "open-telemetry/opentelemetry": "^1.0",
     "php-http/guzzle7-adapter": "^1.0"
   },
+  "require-dev": {
+    "phpunit/phpunit": "^9.5"
+  },
   "autoload": {
     "psr-4": {
       "Google\\GoogleSqlCommenterLaravel\\": "src"
@@ -30,9 +33,6 @@
   },
   "scripts": {
     "format": "phpcbf --standard=psr2 src/"
-  },
-  "require-dev": {
-    "phpunit/phpunit": "^9.5"
   },
   "config": {
     "allow-plugins": {

--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,8 @@
       "role": "Developer"
     }],
   "require": {
-    "open-telemetry/opentelemetry": "~0.0.9",
-    "php-http/guzzle7-adapter": "^1.0"
+    "php-http/guzzle7-adapter": "^1.0",
+    "open-telemetry/opentelemetry": "^1.0"
   },
   "autoload": {
     "psr-4": {
@@ -33,5 +33,12 @@
   },
   "require-dev": {
     "phpunit/phpunit": "^9.5"
-  }
+  },
+  "config": {
+    "allow-plugins": {
+      "php-http/discovery": true
+    }
+  },
+  "minimum-stability": "beta",
+  "prefer-stable": true
 }


### PR DESCRIPTION
The Opentelemetry version currently required is no longer valid.
This prepares the package for when the official Opentelemetry v1.0 is released.